### PR TITLE
Update jsDelivr link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,10 +8,10 @@
 
 The `MojsCurveEditor` depends on `mojs >= 0.225.2`, tween autoupdates available for `mojs >= 0.276.2`. Please make sure you've linked [mojs](https://github.com/legomushroom/mojs) library first.
 
-[CDN](https://www.jsdelivr.com/)(pending approval):
+[CDN](https://www.jsdelivr.com/):
 
 ```
-<script src="//cdn.jsdelivr.net/mojs-curve-editor/latest/mojs-curve-editor.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/mojs-curve-editor@latest/app/build/mojs-curve-editor.min.js"></script>
 ```
 
 [NPM](https://www.npmjs.com/):


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/mojs-curve-editor.

Feel free to ping me if you have any questions regarding this change.